### PR TITLE
feat(snippet): add configurable Last Modified header updates

### DIFF
--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -115,10 +115,16 @@
    - 电邮名`Email Name`，配置参数为`g:atv_snippet_email`。假设不需要此选项请配置为`''`，如不配置则自动采用默认配置。配置方法同上。
    - 网站名`Website Name`，配置参数为`g:atv_snippet_website`。假设不需要此选项请配置为`''`，如不配置则自动采用默认配置。配置方法同上。
    - 生成时间`Created On`，根据当前时间自动生成，必生成项。
-   - 修改时间`Last Modified`，根据每一次更改自动更新，必生成项，且在修改文件时自动更新
+   - 修改时间`Last Modified`，默认自动生成并在修改文件时自动更新；如需关闭，可配置`let g:atv_snippet_last_modified = 0`
    - 文件名`File Name`，根据当前文件名自动生成。必生成项。
    - 公司名`Company Name`，配置参数为`g:atv_snippet_company`。假设不需要此选项请配置为`''`，如不配置则自动采用默认配置。此项会生成公司版权声明。配置方法同上。
    - 修改历史`History`，自动生成初版的历史声明。
+
+   例如，如果希望关闭`Last Modified`的生成和自动更新时间，可在`.vimrc(or _vimrc)`中添加：
+
+   ```javascript
+   let g:atv_snippet_last_modified = 0
+   ```
 
    </details>
 
@@ -1286,4 +1292,3 @@ let g:atv_rtl_recursive = 1
 ```
 
 另外，更新`RtlTree`时，总会自动进行递归调用。
-

--- a/plugin/snippet.vim
+++ b/plugin/snippet.vim
@@ -31,6 +31,7 @@ let g:_ATV_SNIPPET_DEFAULTS = {
             \'device':      'Xilinx',
             \'email':       'contact@honk.wang',
             \'website':     'honk.wang',
+            \'last_modified': 1,
             \'albpp_file':  expand("<sfile>:p:h").'/template/albpp.v',
             \'albpp_pos':   '4,13',
             \'albpn_file':  expand("<sfile>:p:h").'/template/albpn.v',
@@ -128,11 +129,15 @@ function s:AddHeader() "{{{1
         let lnum = lnum + 1
     endif
     call append(lnum,    "// Created On    : ".strftime("%Y/%m/%d %H:%M"))
-    call append(lnum+1,  "// Last Modified : ".strftime("%Y/%m/%d %H:%M"))
-    call append(lnum+2,  "// File Name     : ".filename)
-    call append(lnum+3,  "// Description   :")
-    call append(lnum+4,  "//         ")
-    let lnum = lnum + 5
+    let lnum = lnum + 1
+    if g:atv_snippet_last_modified == 1
+        call append(lnum, "// Last Modified : ".strftime("%Y/%m/%d %H:%M"))
+        let lnum = lnum + 1
+    endif
+    call append(lnum,    "// File Name     : ".filename)
+    call append(lnum+1,  "// Description   :")
+    call append(lnum+2,  "//         ")
+    let lnum = lnum + 3
     let cursor_lnum = lnum
     if g:atv_snippet_company != ''
         call append(lnum,   "// Copyright (c) ".strftime("%Y ") . g:atv_snippet_company . ".")
@@ -158,6 +163,9 @@ augroup filetype_verilog
     autocmd BufWrite *.sv call s:UpdateLastModifyTime()
 augroup END
 function s:UpdateLastModifyTime() "{{{2
+    if g:atv_snippet_last_modified == 0
+        return
+    endif
     let idx = 0
     for line in getline(1,10)
         let idx = idx + 1


### PR DESCRIPTION
  ## Summary

  Add a snippet configuration option to disable Last Modified generation and automatic updates in Verilog file headers.

  ## Changes

  - add g:atv_snippet_last_modified with default value 1
  - skip inserting // Last Modified : ... when the option is set to 0
  - stop updating existing Last Modified lines on *.v and *.sv writes when the option is set to 0
  - document the new option in the handbook with a .vimrc example

  ## Behavior

  Default behavior remains unchanged.

  When configured with:

  let g:atv_snippet_last_modified = 0

  the plugin will:

  - not generate a Last Modified line in newly added headers
  - not auto-update existing Last Modified lines on save

  ## Manual Testing

  - loaded the plugin with vim -Nu NONE -n -es and sourced plugin/automatic.vim / plugin/snippet.vim
  - created a new Verilog file with g:atv_snippet_att_en=1 and g:atv_snippet_last_modified=0
  - verified the generated header includes Created On and File Name but omits Last Modified
  - saved a file containing an existing Last Modified line with g:atv_snippet_last_modified=0
  - verified the existing timestamp was not updated

  ## Compatibility

  - backward compatible by default
  - no changes to the plugin’s own internal Vimscript header timestamp updates